### PR TITLE
Modified getRootDiskUUID() from " " to ""

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -310,6 +310,6 @@ func getRootDiskUUID() (string, error) {
 	uuidString, _ := exec.Command("sh", "-c", cmd).Output()
 	uuid := strings.Split(string(uuidString), "UUID=\"")[1]
 	uuid = strings.Split(string(uuid), " ")[0]
-	uuid = strings.Replace(uuid, "\"", " ", -1)
+	uuid = strings.Replace(uuid, "\"", "", -1)
 	return string(uuid), nil
 }


### PR DESCRIPTION
Currently getRootDiskUUID function returns the uuid of root disk on its host.
But getRootDiskUUID has a bug involved a blank character.
- original root uuid : "4bc23286-8a5e-445f-8429-0389330841e7 " <- blank
- error in openstack cinder

``` console
raise exception.InvalidUUID(uuid=instance_uuid)\n', 'InvalidUUID: Expected a uuid but received 4bc23286-8a5e-445f-8429-0389330841e7 .\n'
```
