### PR TITLE
Adding Region as configurable parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ Example config.json file:
 
 ```json
 {
-  Endpoint: "http://172.16.140.145:5000/v2.0",
-  Username: "Fred",
-  Password: "FredsPassWord",
-  TenantID: "979ddb6183834b9993954ca6de518c5a"
+  "Endpoint": "http://172.16.140.145:5000/v2.0",
+  "Username": "Fred",
+  "Password": "FredsPassWord",
+  "TenantID": "979ddb6183834b9993954ca6de518c5a",
+  "Region": "RegionOne"
 }
 ```
 V3 Endpoints work as well, but we require one additional piece of information
@@ -39,11 +40,12 @@ it in your config file.  Here's an example of a V3 config:
 
 ```json
 {
-  Endpoint: "http://172.16.140.145/identity/v3",
-  Username: "Fred",
-  Password: "FredsPassWord",
-  TenantID: "979ddb6183834b9993954ca6de518c5a",
-  DomainName: "MyAuthDomain"
+  "Endpoint": "http://172.16.140.145/identity/v3",
+  "Username": "Fred",
+  "Password": "FredsPassWord",
+  "TenantID": "979ddb6183834b9993954ca6de518c5a",
+  "DomainName": "MyAuthDomain",
+  "Region": "RegionOne"
 }
 ```
 
@@ -62,20 +64,21 @@ Configuration options are stored in json format in config.json, the minimum requ
 - InitiatorIFace (default)
 - HostUUID (root disk UUID)
 - InitiatorIP (default interface IP)
+- Region (defaults to "RegionOne")
 
 Example config with additional options:
 
 ```json
 {
-  Endpoint: "http://172.16.140.145:5000/v2.0",
-  Username: "Fred",
-  Password: "FredsPassWord",
-  TenantID: "979ddb6183834b9993954ca6de518c5a",
-  DefaultVolSz: 1,
-  MountPoint: "/mnt/cvols",
-  InitiatorIFace: "/dev/eth4",
-  HostUUID: "219b0670-a214-4281-8424-5bb3be109ddd",
-  InitiatorIP: "192.168.4.201"
+  "Endpoint": "http://172.16.140.145:5000/v2.0",
+  "Username": "Fred",
+  "Password": "FredsPassWord",
+  "TenantID": "979ddb6183834b9993954ca6de518c5a",
+  "DefaultVolSz": 1,
+  "MountPoint": "/mnt/cvols",
+  "InitiatorIFace": "/dev/eth4",
+  "HostUUID": "219b0670-a214-4281-8424-5bb3be109ddd",
+  "InitiatorIP": "192.168.4.201"
 }
 ```
 ## Start the daemon

--- a/config.json
+++ b/config.json
@@ -2,5 +2,6 @@
     "Endpoint": "http://172.16.140.245:5000/v2.0",
     "Username": "admin",
     "Password": "solidfire",
-    "TenantID": "092eb256b5b9402abe57d59f58ae3dbc"
+    "TenantID": "092eb256b5b9402abe57d59f58ae3dbc",
+    "Region": "RegionOne"
 }

--- a/driver.go
+++ b/driver.go
@@ -36,6 +36,7 @@ type Config struct {
 	TenantID    string
 	InitiatorIP string
 	DomainName  string
+	Region	    string
 }
 
 type CinderDriver struct {
@@ -140,8 +141,13 @@ func New(cfgFile string) CinderDriver {
 		log.Fatal("Error initiating gophercloud provider client: ", err)
 	}
 
-	client, err := openstack.NewBlockStorageV2(providerClient,
-		gophercloud.EndpointOpts{Region: "RegionOne"})
+	// Set the default region to RegionOne, the OpenStack default
+	endpointOpts := gophercloud.EndpointOpts{Region: conf.Region}
+	if endpointOpts.Region == "" {
+		endpointOpts.Region = "RegionOne"
+	}
+
+	client, err := openstack.NewBlockStorageV2(providerClient, endpointOpts)
 	if err != nil {
 		log.Fatal("Error initiating gophercloud cinder client: ", err)
 	}

--- a/driver.go
+++ b/driver.go
@@ -28,6 +28,7 @@ type Config struct {
 	MountPoint     string
 	InitiatorIFace string //iface to use of iSCSI initiator
 	HostUUID       string
+	SocketGroup    string //Usergroup to use for the plugin socket
 
 	// Cinder credentials
 	Endpoint    string
@@ -134,6 +135,11 @@ func New(cfgFile string) CinderDriver {
 	if conf.DomainName != "" && isV3 == true {
 		log.Info("Authorizing to a V3 Endpoint")
 		auth.DomainName = conf.DomainName
+	}
+
+	// set the default SocketGroup to root, which should work on most Linuxes
+	if conf.SocketGroup == "" {
+		conf.SocketGroup = "root"
 	}
 
 	providerClient, err := openstack.AuthenticatedClient(auth)

--- a/main.go
+++ b/main.go
@@ -36,5 +36,5 @@ func main() {
 	log.Info("Starting cinder-docker-driver version: ", VERSION)
 	d := New(*cfgFile)
 	h := volume.NewHandler(d)
-	log.Info(h.ServeUnix("root", "cinder"))
+	log.Info(h.ServeUnix(d.Conf.SocketGroup, "cinder"))
 }


### PR DESCRIPTION
To support using the driver on OpenStack environments with multiple regions (or a non-default name) I've added 'Region' as configurable parameter. I'm not completely sure if we'd want to default to "RegionOne" as value but I've added it for compatibility just in case. Using these changes it's now possible to use the driver on the OpenStack platform of OVH.com.

Finally I've also updated the example configs to include double quotes around the attribute names as those are required by the JSON parser.

I think these changes should be safe to be merged in but let me know if you see any issues!

Thanks,