### PR TITLE
Fix critical issue regarding non-empty volume mount point

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ sudo ./install.sh
 Use curl to download and run the install script in the package Github repo::
 
 ```shell
-curl -sSL https://raw.githubusercontent.com/ju-la-berger/cinder-docker-driver/v0.13-rc4/install.sh | sudo sh
+curl -sSL https://raw.githubusercontent.com/ju-la-berger/cinder-docker-driver/v0.13-rc5/install.sh | sudo sh
 ```
 ## Configuration options
 Example config.json file:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ sudo ./install.sh
 Use curl to download and run the install script in the package Github repo::
 
 ```shell
-curl -sSL https://raw.githubusercontent.com/ju-la-berger/cinder-docker-driver/v0.13-rc3/install.sh | sudo sh
+curl -sSL https://raw.githubusercontent.com/ju-la-berger/cinder-docker-driver/v0.13-rc4/install.sh | sudo sh
 ```
 ## Configuration options
 Example config.json file:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ with containers.
 
 ### Build From Source
 ```shell
-git clone https://github.com/j-griffith/cinder-docker-driver
+git clone https://github.com/ju-la-berger/cinder-docker-driver
 cd cinder-docker-driver
 go build
 sudo ./install.sh
@@ -18,7 +18,7 @@ sudo ./install.sh
 Use curl to download and run the install script in the package Github repo::
 
 ```shell
-curl -sSl https://raw.githubusercontent.com/j-griffith/cinder-docker-driver/master/install.sh | sh
+curl -sSL https://raw.githubusercontent.com/ju-la-berger/cinder-docker-driver/v0.13/install.sh | sudo sh
 ```
 ##Configuration options
 Example config.json file:

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Example config.json file:
 
 ```json
 {
-  Endpoint: "http://172.16.140.145:5000/v2.0",
-  Username: "Fred",
-  Password: "FredsPassWord",
-  TenantID: "979ddb6183834b9993954ca6de518c5a"
+  "Endpoint": "http://172.16.140.145:5000/v2.0",
+  "Username": "Fred",
+  "Password": "FredsPassWord",
+  "TenantID": "979ddb6183834b9993954ca6de518c5a"
 }
 ```
 V3 Endpoints work as well, but we require one additional piece of information
@@ -39,11 +39,11 @@ it in your config file.  Here's an example of a V3 config:
 
 ```json
 {
-  Endpoint: "http://172.16.140.145/identity/v3",
-  Username: "Fred",
-  Password: "FredsPassWord",
-  TenantID: "979ddb6183834b9993954ca6de518c5a",
-  DomainName: "MyAuthDomain"
+  "Endpoint": "http://172.16.140.145/identity/v3",
+  "Username": "Fred",
+  "Password": "FredsPassWord",
+  "TenantID": "979ddb6183834b9993954ca6de518c5a",
+  "DomainName": "MyAuthDomain"
 }
 ```
 
@@ -67,15 +67,15 @@ Example config with additional options:
 
 ```json
 {
-  Endpoint: "http://172.16.140.145:5000/v2.0",
-  Username: "Fred",
-  Password: "FredsPassWord",
-  TenantID: "979ddb6183834b9993954ca6de518c5a",
-  DefaultVolSz: 1,
-  MountPoint: "/mnt/cvols",
-  InitiatorIFace: "/dev/eth4",
-  HostUUID: "219b0670-a214-4281-8424-5bb3be109ddd",
-  InitiatorIP: "192.168.4.201"
+  "Endpoint": "http://172.16.140.145:5000/v2.0",
+  "Username": "Fred",
+  "Password": "FredsPassWord",
+  "TenantID": "979ddb6183834b9993954ca6de518c5a",
+  "DefaultVolSz": 1,
+  "MountPoint": "/mnt/cvols",
+  "InitiatorIFace": "/dev/eth4",
+  "HostUUID": "219b0670-a214-4281-8424-5bb3be109ddd",
+  "InitiatorIP": "192.168.4.201"
 }
 ```
 ##Start the daemon

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ sudo ./install.sh
 Use curl to download and run the install script in the package Github repo::
 
 ```shell
-curl -sSL https://raw.githubusercontent.com/ju-la-berger/cinder-docker-driver/v0.13-rc2/install.sh | sudo sh
+curl -sSL https://raw.githubusercontent.com/ju-la-berger/cinder-docker-driver/v0.13-rc3/install.sh | sudo sh
 ```
 ##Configuration options
 Example config.json file:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ sudo ./install.sh
 Use curl to download and run the install script in the package Github repo::
 
 ```shell
-curl -sSL https://raw.githubusercontent.com/ju-la-berger/cinder-docker-driver/v0.13/install.sh | sudo sh
+curl -sSL https://raw.githubusercontent.com/ju-la-berger/cinder-docker-driver/v0.13-rc2/install.sh | sudo sh
 ```
 ##Configuration options
 Example config.json file:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ sudo ./install.sh
 Use curl to download and run the install script in the package Github repo::
 
 ```shell
-curl -sSL https://raw.githubusercontent.com/ju-la-berger/cinder-docker-driver/v0.13-rc5/install.sh | sudo sh
+curl -sSL https://raw.githubusercontent.com/ju-la-berger/cinder-docker-driver/v0.13.0/install.sh | sudo sh
 ```
 ## Configuration options
 Example config.json file:

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -e
 
-declare -r BIN_NAME="cinder-docker-driver"
-declare -r DRIVER_URL="https://github.com/ju-la-berger/cinder-docker-driver/releases/download/v0.13-rc4/cinder-docker-driver.linux-amd64"
-declare -r BIN_DIR="/usr/bin"
+BIN_NAME="cinder-docker-driver"
+DRIVER_URL="https://github.com/ju-la-berger/cinder-docker-driver/releases/download/v0.13-rc5/cinder-docker-driver.linux-amd64"
+BIN_DIR="/usr/bin"
 
-function do_install {
+do_install () {
     mkdir -p /var/lib/cinder/dockerdriver
     mkdir -p /var/lib/cinder/mount
     rm ${BIN_DIR}/${BIN_NAME} || true

--- a/install.sh
+++ b/install.sh
@@ -1,38 +1,32 @@
 #!/bin/sh
 set -e
-#
-# This script provides a mechanism for easy installation of the
-# cinder-docker-driver, use with curl or wget:
-#  'curl -sSl https://raw.githubusercontent.com/j-griffith/cinder-docker-driver/master/install.sh | sh''
-# or
-#  'wget -qO- https://raw.githubusercontent.com/j-griffith/cinder-docker-driver/master/install.sh | sh'
 
-BIN_NAME=cinder-docker-driver
-DRIVER_URL="https://github.com/ju-la-berger/cinder-docker-driver/releases/download/v0.13-rc4/cinder-docker-driver"
-BIN_DIR="/usr/bin"
+declare -r BIN_NAME="cinder-docker-driver"
+declare -r DRIVER_URL="https://github.com/ju-la-berger/cinder-docker-driver/releases/download/v0.13-rc4/cinder-docker-driver"
+declare -r BIN_DIR="/usr/bin"
 
-do_install() {
-mkdir -p /var/lib/cinder/dockerdriver
-mkdir -p /var/lib/cinder/mount
-rm $BIN_DIR/$BIN_NAME || true
-curl -sSL -o $BIN_DIR/$BIN_NAME $DRIVER_URL
-chmod +x $BIN_DIR/$BIN_NAME
-echo "
-[Unit]
-Description=\"Cinder Docker Plugin daemon\"
-Before=docker.service
-Requires=cinder-docker-driver.service
+function do_install {
+    mkdir -p /var/lib/cinder/dockerdriver
+    mkdir -p /var/lib/cinder/mount
+    rm ${BIN_DIR}/${BIN_NAME} || true
+    curl -sSL -o ${BIN_DIR}/${BIN_NAME} ${DRIVER_URL}
+    chmod +x ${BIN_DIR}/${BIN_NAME}
+    echo "
+    [Unit]
+    Description=\"Cinder Docker Plugin daemon\"
+    Before=docker.service
+    Requires=cinder-docker-driver.service
 
-[Service]
-TimeoutStartSec=0
-ExecStart=/usr/bin/cinder-docker-driver &
+    [Service]
+    TimeoutStartSec=0
+    ExecStart=/usr/bin/cinder-docker-driver &
 
-[Install]
-WantedBy=docker.service" >/etc/systemd/system/cinder-docker-driver.service
+    [Install]
+    WantedBy=docker.service" >/etc/systemd/system/cinder-docker-driver.service
 
-chmod 644 /etc/systemd/system/cinder-docker-driver.service
-systemctl daemon-reload
-systemctl enable cinder-docker-driver
+    chmod 644 /etc/systemd/system/cinder-docker-driver.service
+    systemctl daemon-reload
+    systemctl enable cinder-docker-driver
 }
 
 do_install

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ set -e
 #  'wget -qO- https://raw.githubusercontent.com/j-griffith/cinder-docker-driver/master/install.sh | sh'
 
 BIN_NAME=cinder-docker-driver
-DRIVER_URL="https://github.com/ju-la-berger/cinder-docker-driver/releases/download/v0.13-rc2/cinder-docker-driver"
+DRIVER_URL="https://github.com/ju-la-berger/cinder-docker-driver/releases/download/v0.13-rc3/cinder-docker-driver"
 BIN_DIR="/usr/bin"
 
 do_install() {

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ set -e
 #  'wget -qO- https://raw.githubusercontent.com/j-griffith/cinder-docker-driver/master/install.sh | sh'
 
 BIN_NAME=cinder-docker-driver
-DRIVER_URL="https://github.com/ju-la-berger/cinder-docker-driver/releases/download/v0.13/cinder-docker-driver"
+DRIVER_URL="https://github.com/ju-la-berger/cinder-docker-driver/releases/download/v0.13-rc2/cinder-docker-driver"
 BIN_DIR="/usr/bin"
 
 do_install() {

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ set -e
 #  'wget -qO- https://raw.githubusercontent.com/j-griffith/cinder-docker-driver/master/install.sh | sh'
 
 BIN_NAME=cinder-docker-driver
-DRIVER_URL="https://github.com/j-griffith/cinder-docker-driver/releases/download/v0.12/cinder-docker-driver"
+DRIVER_URL="https://github.com/ju-la-berger/cinder-docker-driver/releases/download/v0.13/cinder-docker-driver"
 BIN_DIR="/usr/bin"
 
 do_install() {

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -e
 
 BIN_NAME="cinder-docker-driver"
-DRIVER_URL="https://github.com/ju-la-berger/cinder-docker-driver/releases/download/v0.13-rc5/cinder-docker-driver.linux-amd64"
+DRIVER_URL="https://github.com/ju-la-berger/cinder-docker-driver/releases/download/v0.13.0/cinder-docker-driver.linux-amd64"
 BIN_DIR="/usr/bin"
 
 do_install () {

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ set -e
 #  'wget -qO- https://raw.githubusercontent.com/j-griffith/cinder-docker-driver/master/install.sh | sh'
 
 BIN_NAME=cinder-docker-driver
-DRIVER_URL="https://github.com/ju-la-berger/cinder-docker-driver/releases/download/v0.13-rc3/cinder-docker-driver"
+DRIVER_URL="https://github.com/ju-la-berger/cinder-docker-driver/releases/download/v0.13-rc4/cinder-docker-driver"
 BIN_DIR="/usr/bin"
 
 do_install() {

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -e
 
 declare -r BIN_NAME="cinder-docker-driver"
-declare -r DRIVER_URL="https://github.com/ju-la-berger/cinder-docker-driver/releases/download/v0.13-rc4/cinder-docker-driver"
+declare -r DRIVER_URL="https://github.com/ju-la-berger/cinder-docker-driver/releases/download/v0.13-rc4/cinder-docker-driver.linux-amd64"
 declare -r BIN_DIR="/usr/bin"
 
 function do_install {

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	VERSION = "0.13-rc2"
+	VERSION = "0.13-rc3"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	VERSION = "0.13-rc4"
+	VERSION = "0.13-rc5"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	VERSION = "0.12"
+	VERSION = "0.13"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	VERSION = "0.13"
+	VERSION = "0.13-rc2"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	VERSION = "0.13-rc3"
+	VERSION = "0.13-rc4"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	VERSION = "0.13-rc5"
+	VERSION = "0.13.0"
 )
 
 var (


### PR DESCRIPTION
Some Docker containers (e.g. the official `postgres:9.6`) need the volume mount point to be empty. This is not the case when the mount point is the file system root with it's `lost+found` directory.